### PR TITLE
Update example config

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -1,6 +1,6 @@
 [auth]
 # Rename this file to 'config.ini' before running the script.
-# Plex server URL e.g. localhost:32400
+# Plex server URL e.g. http://localhost:32400
 baseurl =
 # https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 token =


### PR DESCRIPTION
If the protocol is not specified, the requests module will return `"No connection adapters were found for {!r}".format(url))"`