### PR TITLE
Fix windows encoding issue

### DIFF
--- a/plex2letterboxd/plex2letterboxd.py
+++ b/plex2letterboxd/plex2letterboxd.py
@@ -47,7 +47,7 @@ def getImdbId(movie):
 
 def write_csv(sections, output, args):
     """Generate Letterboxd import CSV."""
-    with open(output, 'w', newline='') as f:
+    with open(output, 'w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f)
         writer.writerow(['Title', 'Year', 'imdbID', 'Rating10', 'WatchedDate'])
 


### PR DESCRIPTION
Fix a windows encoding issue:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "\Project\plex2letterboxd\plex2letterboxd\__main__.py", line 4, in <module>
    plex2letterboxd.main()
  File "\plex2letterboxd\plex2letterboxd\plex2letterboxd.py", line 86, in main
    write_csv(sections, args.output, args)
  File "\plex2letterboxd\plex2letterboxd\plex2letterboxd.py", line 67, in write_csv
    writer.writerow([movie.title, movie.year, imdbID, rating, date])
  File "C:\Program Files\Python312\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-4: character maps to <undefined>
```