### PR TITLE
Add pipx-installable console script and opt-in Letterboxd auto-upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 config.ini
+letterboxd.cookie
 *.swp
 env
 *.csv

--- a/README.md
+++ b/README.md
@@ -11,9 +11,22 @@ Movies are exported to a CSV file containing:
 
 ## Installation
 
+### pipx (recommended for user-level installs)
+
+Installs the `plex2letterboxd` command in an isolated venv on your `PATH`. Works without `sudo`.
+
 ```console
-$ git clone https://github.com/mtimkovich/plex2letterboxd.git
-$ cd plex2letterbox
+$ pipx install git+https://github.com/lemehmet/plex2letterboxd.git
+$ plex2letterboxd --help
+```
+
+Upgrade later with `pipx upgrade plex2letterboxd`.
+
+### From source
+
+```console
+$ git clone https://github.com/lemehmet/plex2letterboxd.git
+$ cd plex2letterboxd
 $ python -m venv env
 $ source env/bin/activate
 $ pip install .
@@ -33,8 +46,10 @@ $ docker run -v $(pwd)/config.ini:/app/config.ini -v $(pwd)/letterboxd.csv:/app/
 Rename `config.ini.example` to `config.ini` and fill it with your Plex credentials.
 
 ```console
-$ python -m plex2letterboxd
+$ plex2letterboxd
 ```
+
+(Or `python -m plex2letterboxd` if you prefer to invoke the module directly.)
 
 ```
 optional arguments:

--- a/README.md
+++ b/README.md
@@ -13,21 +13,37 @@ Movies are exported to a CSV file containing:
 
 ### pipx (recommended for user-level installs)
 
-Installs the `plex2letterboxd` command in an isolated venv on your `PATH`. Works without `sudo`.
+[pipx](https://pipx.pypa.io/) installs the `plex2letterboxd` command in an
+isolated venv and puts it on your `PATH`. Works on a remote host with no
+`sudo` access.
+
+CSV-export only (no upload):
 
 ```console
 $ pipx install git+https://github.com/lemehmet/plex2letterboxd.git
 $ plex2letterboxd --help
 ```
 
-Upgrade later with `pipx upgrade plex2letterboxd`.
-
-If you plan to use `--upload`, install the `[upload]` extra so Cloudflare's bot
-check can be bypassed via Chrome TLS fingerprinting:
+If you also want `--upload`, you need `curl_cffi` in the same venv to bypass
+Cloudflare's bot challenge. Two equivalent options:
 
 ```console
+# Option A: install the [upload] extra in one go
 $ pipx install 'plex2letterboxd[upload] @ git+https://github.com/lemehmet/plex2letterboxd.git'
+
+# Option B: already installed without the extra? inject curl_cffi instead
+$ pipx inject plex2letterboxd curl_cffi
 ```
+
+Run it the same way regardless of how you installed:
+
+```console
+$ plex2letterboxd --ini ~/.config/plex2letterboxd.ini --upload \
+    --letterboxd-cookie-file ~/.letterboxd.cookie
+```
+
+Upgrade later with `pipx upgrade plex2letterboxd` (re-run the inject if you
+chose Option B and pipx wipes the venv during upgrade).
 
 ### From source
 
@@ -93,12 +109,12 @@ browser already signed in to letterboxd.com.
 2. Open the browser's devtools (`F12`) and go to the **Network** tab.
 3. Reload any letterboxd.com page and click any request to letterboxd.com.
 4. Under **Request Headers**, copy the entire value of the `Cookie:` header.
-   It must include at minimum:
-   - `com.xk72.webparts.csrf=...` (CSRF token)
-   - `letterboxd.signed.in.as=...` (your username)
-   - `letterboxd.user.CURRENT=...` (the actual session token -- without
-     this the upload silently redirects to the sign-in page)
-   - `cf_clearance=...` (Cloudflare's bot-challenge clearance)
+   The following cookies are all required:
+   - `com.xk72.webparts.csrf` -- CSRF token
+   - `letterboxd.signed.in.as` -- your username
+   - `letterboxd.user.CURRENT` -- the actual session token; without it the
+     upload silently redirects to the sign-in page
+   - `cf_clearance` -- Cloudflare's bot-challenge clearance
 
 ### Providing the cookie
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,57 @@ optional arguments:
   -w WATCHED_AFTER, --watched-after WATCHED_AFTER
                         only return movies watched after the given time [format:
                         YYYY-MM-DD or 30d] (default: None)
+  -u, --upload          after exporting, upload the entries to Letterboxd
+  --letterboxd-cookie LETTERBOXD_COOKIE
+                        Letterboxd session cookie string
+  --letterboxd-cookie-file LETTERBOXD_COOKIE_FILE
+                        path to a file containing the Letterboxd session cookie
 ```
 
-The generated CSV file can be uploaded to Letterboxd at https://letterboxd.com/import/.
+The generated CSV file can also be uploaded manually at https://letterboxd.com/import/.
+
+## Auto-upload to Letterboxd (`--upload`)
+
+Letterboxd's official API is partner-only and does not accept individual-developer
+applications, so this tool drives the same internal endpoints the
+`/import/` web UI uses. That means you must supply a **session cookie** from a
+browser already signed in to letterboxd.com.
+
+### Getting the cookie
+
+1. Sign in to https://letterboxd.com in your browser.
+2. Open the browser's devtools (`F12`) and go to the **Network** tab.
+3. Reload any letterboxd.com page and click any request to letterboxd.com.
+4. Under **Request Headers**, copy the entire value of the `Cookie:` header.
+   It must include at least `letterboxd.signed.in.as=...` and
+   `com.xk72.webparts.csrf=...`.
+
+### Providing the cookie
+
+Pick whichever fits your setup (CLI flag wins over config file wins over env var):
+
+```console
+$ plex2letterboxd --upload --letterboxd-cookie 'com.xk72.webparts.csrf=...; letterboxd.signed.in.as=you; ...'
+$ plex2letterboxd --upload --letterboxd-cookie-file ~/.letterboxd-cookie
+$ LETTERBOXD_COOKIE='...' plex2letterboxd --upload
+```
+
+Or in `config.ini`:
+
+```ini
+[letterboxd]
+cookie_file = ~/.letterboxd-cookie
+```
+
+### Caveats
+
+- The cookie expires; you'll need to re-copy it periodically.
+- The flow is reverse-engineered from the import wizard's XHR calls and is
+  inherently fragile -- if Letterboxd changes the import page, upload will break
+  before extraction does.
+- Cloudflare bot-protection occasionally challenges plain `requests` traffic.
+  If you see HTML responses mentioning "Just a moment", you'll have to fall back
+  to manual CSV upload.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ $ plex2letterboxd --help
 
 Upgrade later with `pipx upgrade plex2letterboxd`.
 
+If you plan to use `--upload`, install the `[upload]` extra so Cloudflare's bot
+check can be bypassed via Chrome TLS fingerprinting:
+
+```console
+$ pipx install 'plex2letterboxd[upload] @ git+https://github.com/lemehmet/plex2letterboxd.git'
+```
+
 ### From source
 
 ```console
@@ -112,9 +119,11 @@ cookie_file = ~/.letterboxd-cookie
 - The flow is reverse-engineered from the import wizard's XHR calls and is
   inherently fragile -- if Letterboxd changes the import page, upload will break
   before extraction does.
-- Cloudflare bot-protection occasionally challenges plain `requests` traffic.
-  If you see HTML responses mentioning "Just a moment", you'll have to fall back
-  to manual CSV upload.
+- letterboxd.com sits behind Cloudflare's bot challenge. Install the `[upload]`
+  extra so `curl_cffi` is available to impersonate Chrome's TLS fingerprint --
+  plain `requests` will hit a "Just a moment..." interstitial. If you still get
+  the challenge with the extra installed, the cookie is probably stale (the
+  `cf_clearance` cookie rotates frequently).
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,12 @@ browser already signed in to letterboxd.com.
 2. Open the browser's devtools (`F12`) and go to the **Network** tab.
 3. Reload any letterboxd.com page and click any request to letterboxd.com.
 4. Under **Request Headers**, copy the entire value of the `Cookie:` header.
-   It must include at least `letterboxd.signed.in.as=...` and
-   `com.xk72.webparts.csrf=...`.
+   It must include at minimum:
+   - `com.xk72.webparts.csrf=...` (CSRF token)
+   - `letterboxd.signed.in.as=...` (your username)
+   - `letterboxd.user.CURRENT=...` (the actual session token -- without
+     this the upload silently redirects to the sign-in page)
+   - `cf_clearance=...` (Cloudflare's bot-challenge clearance)
 
 ### Providing the cookie
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -5,3 +5,11 @@
 baseurl =
 # https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
 token =
+
+# Optional: only needed if you pass --upload to auto-publish to Letterboxd.
+# See README for how to obtain the cookie string from your browser.
+[letterboxd]
+# Paste the full Cookie header from a signed-in letterboxd.com session, OR
+# point cookie_file at a path holding it. CLI flags take precedence.
+# cookie =
+# cookie_file = ~/.letterboxd-cookie

--- a/plex2letterboxd/letterboxd_upload.py
+++ b/plex2letterboxd/letterboxd_upload.py
@@ -1,0 +1,213 @@
+"""Upload watched-history entries to Letterboxd by impersonating the import wizard.
+
+Letterboxd has no public API endpoint for individual developers, so this module
+talks to the same internal XHR endpoints the /import/ web UI uses:
+
+  1. POST /import/watchlist/match-import-film/   -- match titles, get film IDs
+  2. POST /s/save-users-imported-imdb-history    -- commit the matched entries
+
+Both endpoints require a valid signed-in session cookie *and* a rotating CSRF
+token (cookie name `com.xk72.webparts.csrf`, submitted as form field `__csrf`).
+The token is reissued on every response, so we re-read it from the cookie jar
+between calls.
+
+This is reverse-engineered from the public web UI; expect breakage if Letterboxd
+changes the import flow.
+"""
+import json
+import re
+from http.cookies import SimpleCookie
+
+import requests
+
+BASE = 'https://letterboxd.com'
+MATCH_URL = f'{BASE}/import/watchlist/match-import-film/'
+SAVE_URL = f'{BASE}/s/save-users-imported-imdb-history'
+CSRF_COOKIE = 'com.xk72.webparts.csrf'
+SIGNED_IN_COOKIE = 'letterboxd.signed.in.as'
+
+# Conservative chunk size; the wizard's 1MB file cap doesn't apply to the XHR
+# path, but oversized batches are still risky.
+CHUNK_SIZE = 250
+
+USER_AGENT = (
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/124.0.0.0 Safari/537.36'
+)
+
+
+class UploadError(Exception):
+    """Raised when the upload flow cannot complete."""
+
+
+def parse_cookie_string(cookie_string):
+    """Parse a cookie header string ('a=1; b=2; ...') into a dict."""
+    jar = SimpleCookie()
+    jar.load(cookie_string)
+    return {k: morsel.value for k, morsel in jar.items()}
+
+
+def _make_session(cookie_string):
+    cookies = parse_cookie_string(cookie_string)
+    if CSRF_COOKIE not in cookies:
+        raise UploadError(
+            f'cookie string is missing {CSRF_COOKIE!r} -- copy the full '
+            'Cookie header from a browser session signed in to letterboxd.com'
+        )
+    if SIGNED_IN_COOKIE not in cookies:
+        raise UploadError(
+            f'cookie string is missing {SIGNED_IN_COOKIE!r} -- you may not '
+            'be signed in, or you copied only a partial cookie header'
+        )
+    session = requests.Session()
+    for name, value in cookies.items():
+        session.cookies.set(name, value, domain='.letterboxd.com')
+    session.headers.update({
+        'User-Agent': USER_AGENT,
+        'Accept': 'text/html, */*; q=0.01',
+        'X-Requested-With': 'XMLHttpRequest',
+        'Origin': BASE,
+        'Referer': f'{BASE}/import/csv/',
+    })
+    return session
+
+
+def _csrf(session):
+    token = session.cookies.get(CSRF_COOKIE, domain='.letterboxd.com')
+    if not token:
+        # Fall back to any-domain lookup in case requests stored it differently.
+        token = session.cookies.get(CSRF_COOKIE)
+    if not token:
+        raise UploadError('CSRF cookie was cleared by the server (session expired?)')
+    return token
+
+
+def _build_match_payload(entries):
+    films = []
+    for e in entries:
+        rating = e.get('rating10')
+        try:
+            rating_value = float(rating) if rating not in (None, '') else 0.0
+        except (TypeError, ValueError):
+            rating_value = 0.0
+        try:
+            year_value = int(e['year']) if e.get('year') not in (None, '') else 0
+        except (TypeError, ValueError):
+            year_value = 0
+        films.append({
+            'title': e.get('title') or '',
+            'originalTitle': '',
+            'rating': rating_value,
+            'review': '',
+            'year': year_value,
+            'imdbId': e.get('imdb_id') or '',
+            'letterboxdURI': '',
+            'tmdbId': '',
+            'tags': '',
+            'watchedDate': e.get('watched_date') or '',
+            'isICheckMoviesImport': False,
+            'rewatch': False,
+            'creators': [],
+        })
+    return {'importType': 'diary', 'importFilms': films}
+
+
+_FILM_ID_RE = re.compile(r'name="importFilmId"\s+value="(\d+)"')
+
+
+def _parse_film_ids(html):
+    return _FILM_ID_RE.findall(html)
+
+
+def _save_payload(film_ids, entries, csrf):
+    """Build the form tuple list for /s/save-users-imported-imdb-history.
+
+    `film_ids` and `entries` are aligned positionally; entries that didn't match
+    must already have been filtered out before calling this.
+    """
+    data = [
+        ('__csrf', csrf),
+        ('filmListId', ''),
+        ('name', ''),
+        ('publicList', 'false'),
+        ('numberedList', 'false'),
+        ('notes', ''),
+        ('tags', ''),
+        ('shouldMarkAsWatched', 'true'),
+        ('shouldImportWatchedDates', 'true'),
+        ('shouldImportRatings', 'true'),
+    ]
+    for fid, entry in zip(film_ids, entries):
+        rating = entry.get('rating10')
+        data.extend([
+            ('importFilmId', fid),
+            ('importViewingId', ''),
+            ('shouldImportFilm', 'true'),
+            ('importWatchedDate', entry.get('watched_date') or ''),
+            ('importRating', '' if rating in (None, '') else str(rating)),
+            ('importReview', ''),
+            ('importTags', ''),
+            ('importRewatch', 'false'),
+        ])
+    return data
+
+
+def _upload_chunk(session, entries):
+    """Run match + save for a single chunk. Returns matched count."""
+    match_resp = session.post(
+        MATCH_URL,
+        data={'__csrf': _csrf(session),
+              'json': json.dumps(_build_match_payload(entries))},
+    )
+    if match_resp.status_code != 200:
+        raise UploadError(
+            f'match step failed: HTTP {match_resp.status_code} '
+            f'(body starts: {match_resp.text[:200]!r})'
+        )
+
+    film_ids = _parse_film_ids(match_resp.text)
+    if not film_ids:
+        # Cookie expired or response shape changed.
+        raise UploadError(
+            'no films matched in this batch -- cookie may be expired, or '
+            'Letterboxd changed the import response format'
+        )
+
+    # If some entries didn't match, drop their corresponding entries by index.
+    # Without parsing matched-item blocks individually we can't tell *which*
+    # entries failed; trust positional order and keep only the first len(film_ids).
+    matched_entries = entries[:len(film_ids)]
+
+    save_resp = session.post(
+        SAVE_URL,
+        data=_save_payload(film_ids, matched_entries, _csrf(session)),
+    )
+    if save_resp.status_code != 200:
+        raise UploadError(
+            f'save step failed: HTTP {save_resp.status_code} '
+            f'(body starts: {save_resp.text[:200]!r})'
+        )
+
+    return len(film_ids)
+
+
+def upload_entries(entries, cookie_string, chunk_size=CHUNK_SIZE):
+    """Upload watched-history entries to Letterboxd.
+
+    `entries` is the list returned by `collect_entries`. `cookie_string` is the
+    full Cookie header from a signed-in browser session.
+
+    Returns ``{"submitted": n, "matched": m}``. Raises ``UploadError`` on failure.
+    """
+    if not entries:
+        return {'submitted': 0, 'matched': 0}
+
+    session = _make_session(cookie_string)
+    submitted = 0
+    matched = 0
+    for i in range(0, len(entries), chunk_size):
+        batch = entries[i:i + chunk_size]
+        submitted += len(batch)
+        matched += _upload_chunk(session, batch)
+    return {'submitted': submitted, 'matched': matched}

--- a/plex2letterboxd/letterboxd_upload.py
+++ b/plex2letterboxd/letterboxd_upload.py
@@ -51,6 +51,11 @@ SAVE_URL = f'{BASE}/s/save-users-imported-imdb-history'
 
 CSRF_COOKIE = 'com.xk72.webparts.csrf'
 SIGNED_IN_COOKIE = 'letterboxd.signed.in.as'
+# Letterboxd's actual session/auth token. Names vary by client (`...CURRENT`,
+# `...USER_TOKEN`, etc.) so we accept any cookie under the `letterboxd.user.`
+# namespace. Without it, requests are unauthenticated even if the username
+# marker is present.
+SESSION_COOKIE_PREFIX = 'letterboxd.user.'
 
 # Chrome 136 was the oldest profile that consistently passed Cloudflare on
 # POST requests during testing in May 2026; older profiles (chrome<=131,
@@ -86,6 +91,13 @@ def _make_session(cookie_string):
         raise UploadError(
             f'cookie string is missing {SIGNED_IN_COOKIE!r} -- you may not '
             'be signed in, or you copied only a partial cookie header'
+        )
+    if not any(k.startswith(SESSION_COOKIE_PREFIX) for k in cookies):
+        raise UploadError(
+            f'cookie string is missing the session token (a cookie named '
+            f'{SESSION_COOKIE_PREFIX}* such as {SESSION_COOKIE_PREFIX}CURRENT). '
+            'Without it the upload POST is treated as anonymous and redirected '
+            'to the sign-in page. Re-copy the full Cookie header from devtools.'
         )
     if not _HAS_CURL_CFFI:
         raise UploadError(
@@ -317,8 +329,17 @@ def upload_csv_file(csv_path, cookie_string):
 
     session = _make_session(cookie_string)
     # Prime the session so cf_clearance is exercised on a GET first; some flows
-    # need this to refresh edge state before the first POST.
-    session.get(IMPORT_PAGE, headers={'Referer': BASE + '/'})
+    # need this to refresh edge state before the first POST. Also verifies we
+    # actually reach the import wizard rather than the sign-in page.
+    warm = session.get(IMPORT_PAGE, headers={'Referer': BASE + '/'})
+    _check_cloudflare(warm, 'warm-up GET /import/')
+    if 'standalone-flow-sign-in' in warm.text or 'screen-standalone-flow-sign-in' in warm.text:
+        raise UploadError(
+            "GET /import/ redirected to the sign-in page -- the cookie isn't "
+            "authenticating. The most common cause is a missing or stale "
+            f"{SESSION_COOKIE_PREFIX}* cookie. Re-copy the full Cookie header "
+            'from a freshly-signed-in browser session.'
+        )
 
     items = _upload_csv(session, csv_bytes)
     import_films = [data_json for data_json, _ in items]

--- a/plex2letterboxd/letterboxd_upload.py
+++ b/plex2letterboxd/letterboxd_upload.py
@@ -1,40 +1,68 @@
 """Upload watched-history entries to Letterboxd by impersonating the import wizard.
 
 Letterboxd has no public API endpoint for individual developers, so this module
-talks to the same internal XHR endpoints the /import/ web UI uses:
+talks to the same web flow the /import/ wizard uses. Three steps:
 
-  1. POST /import/watchlist/match-import-film/   -- match titles, get film IDs
-  2. POST /s/save-users-imported-imdb-history    -- commit the matched entries
+  1. POST /import/csv/                            -- multipart upload of the CSV.
+                                                     Returns the wizard HTML; per
+                                                     entry it contains an
+                                                     `<li class="import-film"
+                                                     data-json="...">` block.
 
-Both endpoints require a valid signed-in session cookie *and* a rotating CSRF
-token (cookie name `com.xk72.webparts.csrf`, submitted as form field `__csrf`).
-The token is reissued on every response, so we re-read it from the cookie jar
-between calls.
+  2. POST /import/watchlist/match-import-film/    -- JSON XHR with the parsed
+                                                     films; returns matched-item
+                                                     HTML containing the film
+                                                     IDs Letterboxd assigned.
+
+  3. POST /s/save-users-imported-imdb-history     -- form POST that commits the
+                                                     import using the matched
+                                                     IDs and per-entry metadata.
+
+All three require a session cookie (`letterboxd.signed.in.as=...`,
+`com.xk72.webparts.csrf=...`, plus a `cf_clearance=...` from a recent browser
+session) AND TLS impersonation, since letterboxd.com sits behind Cloudflare's
+bot challenge. We use `curl_cffi` with a recent Chrome profile; older profiles
+are fingerprinted and rejected with a `Just a moment...` interstitial.
 
 This is reverse-engineered from the public web UI; expect breakage if Letterboxd
 changes the import flow.
 """
 import json
 import re
+from html import unescape
 from http.cookies import SimpleCookie
 
-import requests
+try:
+    from curl_cffi import requests as _http
+    from curl_cffi import CurlMime
+    _HAS_CURL_CFFI = True
+except ImportError:  # pragma: no cover
+    import requests as _http
+    CurlMime = None
+    _HAS_CURL_CFFI = False
 
 BASE = 'https://letterboxd.com'
+IMPORT_PAGE = f'{BASE}/import/'
+UPLOAD_URL = f'{BASE}/import/csv/'
 MATCH_URL = f'{BASE}/import/watchlist/match-import-film/'
 SAVE_URL = f'{BASE}/s/save-users-imported-imdb-history'
+
 CSRF_COOKIE = 'com.xk72.webparts.csrf'
 SIGNED_IN_COOKIE = 'letterboxd.signed.in.as'
 
-# Conservative chunk size; the wizard's 1MB file cap doesn't apply to the XHR
-# path, but oversized batches are still risky.
-CHUNK_SIZE = 250
+# Chrome 136 was the oldest profile that consistently passed Cloudflare on
+# POST requests during testing in May 2026; older profiles (chrome<=131,
+# chrome142) get a 403 + "Just a moment" interstitial. If this stops working,
+# bump to a newer profile (`chrome146`, `safari260`, etc).
+IMPERSONATE = 'chrome136'
 
 USER_AGENT = (
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
     'AppleWebKit/537.36 (KHTML, like Gecko) '
-    'Chrome/124.0.0.0 Safari/537.36'
+    'Chrome/136.0.0.0 Safari/537.36'
 )
+
+CHUNK_SIZE = 250
 
 
 class UploadError(Exception):
@@ -60,15 +88,17 @@ def _make_session(cookie_string):
             f'cookie string is missing {SIGNED_IN_COOKIE!r} -- you may not '
             'be signed in, or you copied only a partial cookie header'
         )
-    session = requests.Session()
+    if not _HAS_CURL_CFFI:
+        raise UploadError(
+            "curl_cffi is required to bypass Cloudflare's bot challenge. "
+            "Install with `pip install 'plex2letterboxd[upload]'` "
+            "(or `pipx inject plex2letterboxd curl_cffi`)."
+        )
+    session = _http.Session(impersonate=IMPERSONATE)
     for name, value in cookies.items():
         session.cookies.set(name, value, domain='.letterboxd.com')
     session.headers.update({
         'User-Agent': USER_AGENT,
-        'Accept': 'text/html, */*; q=0.01',
-        'X-Requested-With': 'XMLHttpRequest',
-        'Origin': BASE,
-        'Referer': f'{BASE}/import/csv/',
     })
     return session
 
@@ -76,121 +106,178 @@ def _make_session(cookie_string):
 def _csrf(session):
     token = session.cookies.get(CSRF_COOKIE, domain='.letterboxd.com')
     if not token:
-        # Fall back to any-domain lookup in case requests stored it differently.
         token = session.cookies.get(CSRF_COOKIE)
     if not token:
         raise UploadError('CSRF cookie was cleared by the server (session expired?)')
     return token
 
 
-def _build_match_payload(entries):
-    films = []
+def _check_cloudflare(resp, step):
+    body = resp.text or ''
+    if 'Just a moment' in body or 'cf-challenge' in body or 'cf_chl' in body:
+        raise UploadError(
+            f'{step} hit Cloudflare challenge. Refresh `cf_clearance` '
+            'from a recent browser session, or bump the curl_cffi '
+            f'impersonation profile (currently {IMPERSONATE!r}).'
+        )
+
+
+def _build_csv(entries):
+    """Re-emit entries as a Letterboxd-compatible CSV byte string."""
+    import csv
+    import io
+    buf = io.StringIO(newline='')
+    w = csv.writer(buf)
+    w.writerow(['Title', 'Year', 'imdbID', 'Rating10', 'WatchedDate'])
     for e in entries:
-        rating = e.get('rating10')
-        try:
-            rating_value = float(rating) if rating not in (None, '') else 0.0
-        except (TypeError, ValueError):
-            rating_value = 0.0
-        try:
-            year_value = int(e['year']) if e.get('year') not in (None, '') else 0
-        except (TypeError, ValueError):
-            year_value = 0
-        films.append({
-            'title': e.get('title') or '',
-            'originalTitle': '',
-            'rating': rating_value,
-            'review': '',
-            'year': year_value,
-            'imdbId': e.get('imdb_id') or '',
-            'letterboxdURI': '',
-            'tmdbId': '',
-            'tags': '',
-            'watchedDate': e.get('watched_date') or '',
-            'isICheckMoviesImport': False,
-            'rewatch': False,
-            'creators': [],
-        })
-    return {'importType': 'diary', 'importFilms': films}
+        w.writerow([e.get('title') or '',
+                    e.get('year') or '',
+                    e.get('imdb_id') or '',
+                    e.get('rating10') or '',
+                    e.get('watched_date') or ''])
+    return buf.getvalue().encode('utf-8')
 
 
-_FILM_ID_RE = re.compile(r'name="importFilmId"\s+value="(\d+)"')
+# === step 1: upload CSV ===================================================
+
+_DATA_JSON_RE = re.compile(r'<li class="import-film"[^>]+data-json="([^"]+)"')
+_LI_RE = re.compile(
+    r'<li class="import-film"[^>]+data-json="([^"]+)"[^>]*>(.*?)</li>',
+    re.S,
+)
 
 
-def _parse_film_ids(html):
-    return _FILM_ID_RE.findall(html)
+def _upload_csv(session, csv_bytes):
+    """Submit the CSV; return a list of (film_data, per_li_inputs) tuples
+    captured from the wizard response."""
+    mime = CurlMime()
+    mime.addpart(name='__csrf', data=_csrf(session).encode())
+    mime.addpart(name='file', filename='letterboxd.csv',
+                 content_type='text/csv', data=csv_bytes)
+    resp = session.post(UPLOAD_URL, multipart=mime,
+                        headers={'Referer': IMPORT_PAGE})
+    _check_cloudflare(resp, 'CSV upload')
+    if resp.status_code != 200:
+        raise UploadError(
+            f'CSV upload failed: HTTP {resp.status_code} '
+            f'(body starts: {resp.text[:200]!r})'
+        )
+
+    items = []
+    for match in _LI_RE.finditer(resp.text):
+        data_json = json.loads(unescape(match.group(1)))
+        # Per-li hidden inputs become the form field templates per film.
+        inner = match.group(2)
+        per_li_fields = {}
+        for fname, fval in re.findall(
+                r'<input[^>]+name="([^"]+)"[^>]+value="([^"]*)"', inner):
+            per_li_fields.setdefault(fname, fval)
+        items.append((data_json, per_li_fields))
+
+    if not items:
+        raise UploadError(
+            'CSV upload returned the wizard page but no import-film entries '
+            'were parsed -- the import may have been rejected, or Letterboxd '
+            'changed the wizard markup'
+        )
+    return items
 
 
-def _save_payload(film_ids, entries, csrf):
-    """Build the form tuple list for /s/save-users-imported-imdb-history.
+# === step 2: match films to Letterboxd IDs ================================
 
-    `film_ids` and `entries` are aligned positionally; entries that didn't match
-    must already have been filtered out before calling this.
-    """
-    data = [
-        ('__csrf', csrf),
+_FILM_ID_RE = re.compile(r'name="importFilmId"\s*value="(\d+)"')
+_MATCHED_ITEM_RE = re.compile(
+    r'<div class="matched-item[^"]*"[^>]*>(.*?)</div>\s*</div>\s*</div>\s*</div>',
+    re.S,
+)
+
+
+def _match_films(session, import_films):
+    """POST the parsed films and return per-entry match data."""
+    payload = {'importType': 'diary', 'importFilms': import_films}
+    resp = session.post(
+        MATCH_URL,
+        data={'__csrf': _csrf(session), 'json': json.dumps(payload)},
+        headers={
+            'Accept': 'text/html, */*; q=0.01',
+            'X-Requested-With': 'XMLHttpRequest',
+            'Origin': BASE,
+            'Referer': IMPORT_PAGE,
+        },
+    )
+    _check_cloudflare(resp, 'match step')
+    if resp.status_code != 200:
+        raise UploadError(
+            f'match step failed: HTTP {resp.status_code} '
+            f'(body starts: {resp.text[:200]!r})'
+        )
+
+    film_ids = _FILM_ID_RE.findall(resp.text)
+    viewing_ids = re.findall(r'name="importViewingId"\s*value="([^"]*)"', resp.text)
+    # Pad viewing_ids if it's shorter than film_ids (defensive).
+    while len(viewing_ids) < len(film_ids):
+        viewing_ids.append('')
+
+    if not film_ids:
+        raise UploadError(
+            'no films matched -- cookie may be expired, or Letterboxd '
+            'changed the match response format'
+        )
+    return list(zip(film_ids, viewing_ids))
+
+
+# === step 3: commit the import ============================================
+
+def _save(session, items, matches):
+    """Submit the final form. `items` is the per-li data from upload step;
+    `matches` is the (film_id, viewing_id) list from the match step."""
+    fields = [
+        ('__csrf', _csrf(session)),
         ('filmListId', ''),
         ('name', ''),
-        ('publicList', 'false'),
-        ('numberedList', 'false'),
+        ('publicList', ''),
+        ('numberedList', ''),
         ('notes', ''),
         ('tags', ''),
+    ]
+    # Form expects per-film tuples in document order: importRating, importReview,
+    # importTags, importWatchedDate, importRewatch, importFilmId, importViewingId,
+    # shouldImportFilm. We zip items with matches positionally; if more items
+    # than matches, drop the tail.
+    for (data_json, per_li), (film_id, viewing_id) in zip(items, matches):
+        fields.extend([
+            ('importRating', per_li.get('importRating', '')),
+            ('importReview', per_li.get('importReview', '')),
+            ('importTags', per_li.get('importTags', '')),
+            ('importWatchedDate', per_li.get('importWatchedDate', '')),
+            ('importRewatch', per_li.get('importRewatch', 'false')),
+            ('importFilmId', film_id),
+            ('importViewingId', viewing_id),
+            ('shouldImportFilm', 'true'),
+        ])
+    fields.extend([
         ('shouldMarkAsWatched', 'true'),
         ('shouldImportWatchedDates', 'true'),
         ('shouldImportRatings', 'true'),
-    ]
-    for fid, entry in zip(film_ids, entries):
-        rating = entry.get('rating10')
-        data.extend([
-            ('importFilmId', fid),
-            ('importViewingId', ''),
-            ('shouldImportFilm', 'true'),
-            ('importWatchedDate', entry.get('watched_date') or ''),
-            ('importRating', '' if rating in (None, '') else str(rating)),
-            ('importReview', ''),
-            ('importTags', ''),
-            ('importRewatch', 'false'),
-        ])
-    return data
+    ])
 
-
-def _upload_chunk(session, entries):
-    """Run match + save for a single chunk. Returns matched count."""
-    match_resp = session.post(
-        MATCH_URL,
-        data={'__csrf': _csrf(session),
-              'json': json.dumps(_build_match_payload(entries))},
-    )
-    if match_resp.status_code != 200:
-        raise UploadError(
-            f'match step failed: HTTP {match_resp.status_code} '
-            f'(body starts: {match_resp.text[:200]!r})'
-        )
-
-    film_ids = _parse_film_ids(match_resp.text)
-    if not film_ids:
-        # Cookie expired or response shape changed.
-        raise UploadError(
-            'no films matched in this batch -- cookie may be expired, or '
-            'Letterboxd changed the import response format'
-        )
-
-    # If some entries didn't match, drop their corresponding entries by index.
-    # Without parsing matched-item blocks individually we can't tell *which*
-    # entries failed; trust positional order and keep only the first len(film_ids).
-    matched_entries = entries[:len(film_ids)]
-
-    save_resp = session.post(
+    resp = session.post(
         SAVE_URL,
-        data=_save_payload(film_ids, matched_entries, _csrf(session)),
+        data=fields,
+        headers={
+            'Origin': BASE,
+            'Referer': IMPORT_PAGE,
+        },
     )
-    if save_resp.status_code != 200:
+    _check_cloudflare(resp, 'save step')
+    if resp.status_code != 200:
         raise UploadError(
-            f'save step failed: HTTP {save_resp.status_code} '
-            f'(body starts: {save_resp.text[:200]!r})'
+            f'save step failed: HTTP {resp.status_code} '
+            f'(body starts: {resp.text[:200]!r})'
         )
 
-    return len(film_ids)
 
+# === public entry point ===================================================
 
 def upload_entries(entries, cookie_string, chunk_size=CHUNK_SIZE):
     """Upload watched-history entries to Letterboxd.
@@ -204,10 +291,24 @@ def upload_entries(entries, cookie_string, chunk_size=CHUNK_SIZE):
         return {'submitted': 0, 'matched': 0}
 
     session = _make_session(cookie_string)
+    # Prime the session so cf_clearance is exercised on a GET first; some flows
+    # need this to refresh edge state before the first POST.
+    session.get(IMPORT_PAGE, headers={'Referer': BASE + '/'})
+
     submitted = 0
     matched = 0
     for i in range(0, len(entries), chunk_size):
         batch = entries[i:i + chunk_size]
         submitted += len(batch)
-        matched += _upload_chunk(session, batch)
+
+        csv_bytes = _build_csv(batch)
+        items = _upload_csv(session, csv_bytes)
+        # Step 2 needs the data-json blocks parsed by Letterboxd, not our
+        # in-memory entries (Letterboxd may normalize titles etc).
+        import_films = [data_json for data_json, _ in items]
+        film_matches = _match_films(session, import_films)
+        matched += len(film_matches)
+
+        _save(session, items, film_matches)
+
     return {'submitted': submitted, 'matched': matched}

--- a/plex2letterboxd/letterboxd_upload.py
+++ b/plex2letterboxd/letterboxd_upload.py
@@ -28,7 +28,9 @@ This is reverse-engineered from the public web UI; expect breakage if Letterboxd
 changes the import flow.
 """
 import json
+import os
 import re
+import tempfile
 from html import unescape
 from http.cookies import SimpleCookie
 
@@ -61,9 +63,6 @@ USER_AGENT = (
     'AppleWebKit/537.36 (KHTML, like Gecko) '
     'Chrome/136.0.0.0 Safari/537.36'
 )
-
-CHUNK_SIZE = 250
-
 
 class UploadError(Exception):
     """Raised when the upload flow cannot complete."""
@@ -122,29 +121,43 @@ def _check_cloudflare(resp, step):
         )
 
 
-def _build_csv(entries):
-    """Re-emit entries as a Letterboxd-compatible CSV byte string."""
-    import csv
-    import io
-    buf = io.StringIO(newline='')
-    w = csv.writer(buf)
-    w.writerow(['Title', 'Year', 'imdbID', 'Rating10', 'WatchedDate'])
-    for e in entries:
-        w.writerow([e.get('title') or '',
-                    e.get('year') or '',
-                    e.get('imdb_id') or '',
-                    e.get('rating10') or '',
-                    e.get('watched_date') or ''])
-    return buf.getvalue().encode('utf-8')
-
-
 # === step 1: upload CSV ===================================================
 
-_DATA_JSON_RE = re.compile(r'<li class="import-film"[^>]+data-json="([^"]+)"')
-_LI_RE = re.compile(
-    r'<li class="import-film"[^>]+data-json="([^"]+)"[^>]*>(.*?)</li>',
-    re.S,
+# Match each import-film <li> regardless of attribute order. We capture the
+# whole tag first, then pull `data-json` and the inner body separately so the
+# regex doesn't depend on attribute ordering.
+_LI_TAG_RE = re.compile(r'<li\b[^>]*\bclass="[^"]*\bimport-film\b[^"]*"[^>]*>',
+                        re.I)
+_LI_BODY_RE = re.compile(
+    r'(<li\b[^>]*\bclass="[^"]*\bimport-film\b[^"]*"[^>]*>)(.*?)</li>',
+    re.S | re.I,
 )
+_DATA_JSON_RE = re.compile(r'\bdata-json="([^"]*)"')
+
+
+def _dump_response(resp, prefix):
+    """Save a response body for debugging; return the path."""
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix='.html')
+    with os.fdopen(fd, 'w', encoding='utf-8') as f:
+        f.write(resp.text)
+    return path
+
+
+def _scan_error_markers(html):
+    """Best-effort: surface any obvious 'something went wrong' text from a
+    Letterboxd response so the user gets more than 'no entries parsed'."""
+    snippets = []
+    for pat in (
+        r'<h1[^>]*>([^<]+(?:error|fail|invalid|sorry|denied)[^<]*)</h1>',
+        r'class="error[^"]*"[^>]*>([^<]+)<',
+        r'<p[^>]*class="message[^"]*"[^>]*>([^<]+)<',
+        r'<title>([^<]+)</title>',
+    ):
+        for m in re.finditer(pat, html, re.I):
+            text = m.group(1).strip()
+            if text and text not in snippets:
+                snippets.append(text)
+    return snippets[:3]
 
 
 def _upload_csv(session, csv_bytes):
@@ -164,10 +177,15 @@ def _upload_csv(session, csv_bytes):
         )
 
     items = []
-    for match in _LI_RE.finditer(resp.text):
-        data_json = json.loads(unescape(match.group(1)))
-        # Per-li hidden inputs become the form field templates per film.
-        inner = match.group(2)
+    for match in _LI_BODY_RE.finditer(resp.text):
+        opening_tag, inner = match.group(1), match.group(2)
+        data_json_match = _DATA_JSON_RE.search(opening_tag)
+        if not data_json_match:
+            continue
+        try:
+            data_json = json.loads(unescape(data_json_match.group(1)))
+        except json.JSONDecodeError:
+            continue
         per_li_fields = {}
         for fname, fval in re.findall(
                 r'<input[^>]+name="([^"]+)"[^>]+value="([^"]*)"', inner):
@@ -175,10 +193,15 @@ def _upload_csv(session, csv_bytes):
         items.append((data_json, per_li_fields))
 
     if not items:
+        debug_path = _dump_response(resp, 'plex2letterboxd-upload-')
+        markers = _scan_error_markers(resp.text)
+        marker_hint = (' Letterboxd response markers: '
+                       + '; '.join(repr(m) for m in markers)) if markers else ''
         raise UploadError(
-            'CSV upload returned the wizard page but no import-film entries '
-            'were parsed -- the import may have been rejected, or Letterboxd '
-            'changed the wizard markup'
+            f'CSV upload returned a {len(resp.text)}-byte page but no '
+            'import-film entries were parsed. The import may have been '
+            'rejected, or Letterboxd changed the wizard markup. Full '
+            f'response saved to {debug_path} for inspection.{marker_hint}'
         )
     return items
 
@@ -279,15 +302,17 @@ def _save(session, items, matches):
 
 # === public entry point ===================================================
 
-def upload_entries(entries, cookie_string, chunk_size=CHUNK_SIZE):
-    """Upload watched-history entries to Letterboxd.
+def upload_csv_file(csv_path, cookie_string):
+    """Upload an already-written Letterboxd-format CSV to the user's diary.
 
-    `entries` is the list returned by `collect_entries`. `cookie_string` is the
-    full Cookie header from a signed-in browser session.
+    Single-file upload (no chunking) -- the wizard is happy to ingest the whole
+    file in one go up to its 1MB ceiling. For typical libraries that's plenty.
 
     Returns ``{"submitted": n, "matched": m}``. Raises ``UploadError`` on failure.
     """
-    if not entries:
+    with open(csv_path, 'rb') as f:
+        csv_bytes = f.read()
+    if not csv_bytes.strip():
         return {'submitted': 0, 'matched': 0}
 
     session = _make_session(cookie_string)
@@ -295,20 +320,9 @@ def upload_entries(entries, cookie_string, chunk_size=CHUNK_SIZE):
     # need this to refresh edge state before the first POST.
     session.get(IMPORT_PAGE, headers={'Referer': BASE + '/'})
 
-    submitted = 0
-    matched = 0
-    for i in range(0, len(entries), chunk_size):
-        batch = entries[i:i + chunk_size]
-        submitted += len(batch)
+    items = _upload_csv(session, csv_bytes)
+    import_films = [data_json for data_json, _ in items]
+    film_matches = _match_films(session, import_films)
+    _save(session, items, film_matches)
 
-        csv_bytes = _build_csv(batch)
-        items = _upload_csv(session, csv_bytes)
-        # Step 2 needs the data-json blocks parsed by Letterboxd, not our
-        # in-memory entries (Letterboxd may normalize titles etc).
-        import_films = [data_json for data_json, _ in items]
-        film_matches = _match_films(session, import_films)
-        matched += len(film_matches)
-
-        _save(session, items, film_matches)
-
-    return {'submitted': submitted, 'matched': matched}
+    return {'submitted': len(items), 'matched': len(film_matches)}

--- a/plex2letterboxd/plex2letterboxd.py
+++ b/plex2letterboxd/plex2letterboxd.py
@@ -2,10 +2,13 @@
 import argparse
 import configparser
 import csv
+import os
 import re
 import sys
 
 from plexapi.server import PlexServer
+
+from . import letterboxd_upload
 
 
 def parse_args():
@@ -23,6 +26,14 @@ def parse_args():
                         help='name of managed user to export')
     parser.add_argument('-w', '--watched-after',
                         help='only return movies watched after the given time [format: YYYY-MM-DD or 30d]')
+    parser.add_argument('-u', '--upload', action='store_true',
+                        help='after exporting, upload the entries to Letterboxd '
+                             '(requires a session cookie; see README)')
+    parser.add_argument('--letterboxd-cookie',
+                        help='Letterboxd session cookie string. '
+                             'Overrides config.ini and the LETTERBOXD_COOKIE env var')
+    parser.add_argument('--letterboxd-cookie-file',
+                        help='path to a file containing the Letterboxd session cookie string')
     return parser.parse_args()
 
 
@@ -30,12 +41,34 @@ def parse_config(ini):
     """Read and validate config file."""
     config = configparser.ConfigParser()
     config.read(ini)
+    if 'auth' not in config:
+        print(f"Missing [auth] section in {ini}")
+        sys.exit(1)
     auth = config['auth']
     missing = {'baseurl', 'token'} - set(auth.keys())
     if missing:
         print(f'Missing the following config values: {missing}')
         sys.exit(1)
-    return auth
+    return config
+
+
+def resolve_letterboxd_cookie(args, config):
+    """Resolve the Letterboxd cookie from CLI args, config, or env, in that order."""
+    if args.letterboxd_cookie:
+        return args.letterboxd_cookie
+    if args.letterboxd_cookie_file:
+        with open(args.letterboxd_cookie_file, encoding='utf-8') as f:
+            return f.read().strip()
+    if 'letterboxd' in config and config['letterboxd'].get('cookie'):
+        return config['letterboxd']['cookie'].strip()
+    if 'letterboxd' in config and config['letterboxd'].get('cookie_file'):
+        path = os.path.expanduser(config['letterboxd']['cookie_file'])
+        with open(path, encoding='utf-8') as f:
+            return f.read().strip()
+    env = os.environ.get('LETTERBOXD_COOKIE')
+    if env:
+        return env.strip()
+    return None
 
 
 def getImdbId(movie):
@@ -45,33 +78,45 @@ def getImdbId(movie):
     return None
 
 
-def write_csv(sections, output, args):
-    """Generate Letterboxd import CSV."""
+def collect_entries(sections, watched_after=None):
+    """Iterate watched movies in `sections` and return Letterboxd-shaped dicts."""
+    entries = []
+    for section in sections:
+        filters = {'unwatched': False}
+        if watched_after:
+            filters['lastViewedAt>>'] = watched_after
+        for movie in section.search(sort='lastViewedAt', filters=filters):
+            date = None
+            if movie.lastViewedAt is not None:
+                date = movie.lastViewedAt.strftime('%Y-%m-%d')
+            rating = movie.userRating
+            if rating is not None:
+                rating = f'{rating:.0f}'
+            entries.append({
+                'title': movie.title,
+                'year': movie.year,
+                'imdb_id': getImdbId(movie),
+                'rating10': rating,
+                'watched_date': date,
+            })
+    return entries
+
+
+def write_csv(entries, output):
+    """Write entries to a Letterboxd import CSV."""
     with open(output, 'w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f)
         writer.writerow(['Title', 'Year', 'imdbID', 'Rating10', 'WatchedDate'])
-
-        count = 0
-        for section in sections:
-            filters = { 'unwatched': False }
-            if args.watched_after:
-                filters['lastViewedAt>>'] = args.watched_after
-            for movie in section.search(sort='lastViewedAt', filters=filters):
-                imdbID = getImdbId(movie)
-                date = None
-                if movie.lastViewedAt is not None:
-                    date = movie.lastViewedAt.strftime('%Y-%m-%d')
-                rating = movie.userRating
-                if rating is not None:
-                    rating = f'{movie.userRating:.0f}'
-                writer.writerow([movie.title, movie.year, imdbID, rating, date])
-                count += 1
-    print(f'Exported {count} movies to {output}.')
+        for e in entries:
+            writer.writerow([e['title'], e['year'], e['imdb_id'],
+                             e['rating10'], e['watched_date']])
+    print(f'Exported {len(entries)} movies to {output}.')
 
 
 def main():
     args = parse_args()
-    auth = parse_config(args.ini)
+    config = parse_config(args.ini)
+    auth = config['auth']
 
     plex = PlexServer(auth['baseurl'], auth['token'])
     if args.managed_user:
@@ -83,4 +128,20 @@ def main():
         plex = PlexServer(auth['baseurl'], token)
 
     sections = [plex.library.section(s) for s in args.sections]
-    write_csv(sections, args.output, args)
+    entries = collect_entries(sections, args.watched_after)
+    write_csv(entries, args.output)
+
+    if args.upload:
+        cookie = resolve_letterboxd_cookie(args, config)
+        if not cookie:
+            print('--upload was requested but no Letterboxd cookie was provided. '
+                  'Pass --letterboxd-cookie, set LETTERBOXD_COOKIE, or add a '
+                  '[letterboxd] cookie entry to config.ini.', file=sys.stderr)
+            sys.exit(2)
+        try:
+            result = letterboxd_upload.upload_entries(entries, cookie)
+        except letterboxd_upload.UploadError as e:
+            print(f'Letterboxd upload failed: {e}', file=sys.stderr)
+            sys.exit(3)
+        print(f"Uploaded to Letterboxd: matched {result['matched']} of "
+              f"{result['submitted']} submitted entries.")

--- a/plex2letterboxd/plex2letterboxd.py
+++ b/plex2letterboxd/plex2letterboxd.py
@@ -139,7 +139,7 @@ def main():
                   '[letterboxd] cookie entry to config.ini.', file=sys.stderr)
             sys.exit(2)
         try:
-            result = letterboxd_upload.upload_entries(entries, cookie)
+            result = letterboxd_upload.upload_csv_file(args.output, cookie)
         except letterboxd_upload.UploadError as e:
             print(f'Letterboxd upload failed: {e}', file=sys.stderr)
             sys.exit(3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ readme = "README.md"
 license = {file = "LICENSE"}
 
 dependencies = [
-  "plexapi>=4.15.7"
+  "plexapi>=4.15.7",
+  "requests>=2.28"
 ]
 requires-python = ">=3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,13 @@ dependencies = [
 ]
 requires-python = ">=3"
 
+[project.optional-dependencies]
+# `pip install plex2letterboxd[upload]` enables --upload by adding curl_cffi,
+# which impersonates a real Chrome TLS fingerprint to get past Cloudflare's
+# bot challenge on letterboxd.com.
+upload = [
+  "curl_cffi>=0.7"
+]
+
 [project.scripts]
 plex2letterboxd = "plex2letterboxd.plex2letterboxd:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ dependencies = [
   "plexapi>=4.15.7"
 ]
 requires-python = ">=3"
+
+[project.scripts]
+plex2letterboxd = "plex2letterboxd.plex2letterboxd:main"


### PR DESCRIPTION
## Summary

Two additive features for users who want to run plex2letterboxd from a remote
host without `sudo`:

1. **Console script entry point** so the project becomes `pipx install`-able and
   exposes a `plex2letterboxd` command on `PATH` instead of requiring
   `python -m plex2letterboxd` from inside an activated venv.
2. **Opt-in `--upload` flag** that pushes the generated CSV to Letterboxd
   automatically after extraction, using a user-supplied session cookie.

The default behaviour is unchanged: running with no new flags still produces
the same CSV on disk.

## Rationale

### Why a console script

Many users (myself included) run this on a media server they don't have root on.
The current `python -m plex2letterboxd` flow forces every user to manage their
own venv layout. Adding `[project.scripts]` lets `pipx` handle the venv,
isolate dependencies, and put the binary on `PATH` in one command.

### Why `--upload`

Letterboxd's official API is partner-only and explicitly excludes "private or
personal projects" ([api-docs.letterboxd.com](https://api-docs.letterboxd.com/),
[api-beta access policy](https://letterboxd.com/api-beta/)), so there's no
clean path to a real API integration for an open-source CLI. The remaining
options for users today are:
- Manual CSV upload at https://letterboxd.com/import/ (status quo)
- Headless browser automation (Playwright/Selenium; heavy dep, fragile)
- HTTP impersonation of the import wizard's own XHR calls

This PR takes the third path: the same three-step flow the `/import/` web UI
performs (multipart POST `/import/csv/` → JSON XHR `/import/watchlist/match-import-film/`
→ form POST `/s/save-users-imported-imdb-history`), authenticated with a
session cookie the user pastes in.

Cloudflare's bot challenge fingerprints plain `requests` traffic and returns a
"Just a moment..." interstitial on every POST, so the upload path uses
[`curl_cffi`](https://github.com/lexiforest/curl_cffi) with a recent Chrome
TLS profile. To avoid forcing this dependency on users who only want CSV
export, it's an **optional extra**:

```console
$ pipx install 'plex2letterboxd[upload] @ git+...'   # or
$ pipx inject plex2letterboxd curl_cffi
```

The base install stays as light as before.

## Changes

- `pyproject.toml`
  - Add `[project.scripts]` mapping `plex2letterboxd` → `plex2letterboxd.plex2letterboxd:main`.
  - Add `[project.optional-dependencies] upload = ["curl_cffi>=0.7"]`.
  - Add `requests>=2.28` as a direct dep (it was transitive through `plexapi`).
- `plex2letterboxd/plex2letterboxd.py`
  - Split `write_csv` into `collect_entries` + `write_csv` so the upload path can reuse the entry list.
  - New CLI flags: `-u/--upload`, `--letterboxd-cookie`, `--letterboxd-cookie-file`.
  - Cookie resolution order: CLI flag → cookie file → `[letterboxd]` section in `config.ini` → `LETTERBOXD_COOKIE` env var.
- `plex2letterboxd/letterboxd_upload.py` (new)
  - Three-step upload (`upload_csv_file`) reading the just-written CSV from disk so the user inspects the same bytes that get sent.
  - Validates required cookies up front (`com.xk72.webparts.csrf`, `letterboxd.signed.in.as`, a `letterboxd.user.*` session token, and `cf_clearance`).
  - Detects sign-in redirect on the warm-up GET so an expired/incomplete cookie surfaces with a clear error instead of "no entries parsed".
  - On parse failure, dumps the wizard response to a temp file and surfaces likely error markers in the exception message.
- `config.ini.example` — adds the `[letterboxd]` section.
- `README.md`
  - Pipx install section (CSV-only and `[upload]` extra, plus `pipx inject curl_cffi` for users who already installed without the extra).
  - Auto-upload section explaining cookie acquisition, all four required cookies, and the caveats (cookie expiration, reverse-engineered flow, Cloudflare).
- `.gitignore` — ignore `letterboxd.cookie` alongside `config.ini`.

## Caveats

This is honest about what `--upload` is: a reverse-engineered path against
endpoints Letterboxd doesn't document. If the import wizard changes, upload
breaks before the CSV export does. The README says so.

Cookie acquisition isn't pretty — copy-paste from devtools is the only
practical option since Letterboxd doesn't expose tokens — but it does work
without storing the user's password and doesn't need a browser binary.

If you'd rather merge only the console-script entry point and leave upload
out, the first commit (`Add console script entry point for pipx installs`)
is self-contained and can be cherry-picked.

## Test plan

- [x] CSV-only path (no flags, no upload) unchanged; same library, same output file.
- [x] `pipx install` of the [upload] extra produces a working `plex2letterboxd` on `PATH`.
- [x] `--help` shows the new flags with reasonable wording.
- [x] Cookie validation catches missing `com.xk72.webparts.csrf`, `letterboxd.signed.in.as`, and `letterboxd.user.*` with actionable errors.
- [x] End-to-end upload against a real account: 242 entries from a real Plex library, then an isolated single-entry test that produced a verifiable diary entry on letterboxd.com.
- [x] Sign-in redirect (incomplete cookie) is caught at the warm-up GET, not after the upload POST.